### PR TITLE
Fix logfile parsing

### DIFF
--- a/py3tftp/cli_parser.py
+++ b/py3tftp/cli_parser.py
@@ -59,7 +59,7 @@ def parse_cli_arguments():
         logging_config['level'] = logging.DEBUG
 
     if args.file_log:
-        logging_config['filename'] = args.log
+        logging_config['filename'] = args.file_log
 
     if args.version:
         print_version()


### PR DESCRIPTION
An `KeyError` was thrown when the `-l`option was used in cli. Fixed that by pointing to the right key `file_log`